### PR TITLE
Improved onnx parsing

### DIFF
--- a/expression_encoding.py
+++ b/expression_encoding.py
@@ -2,6 +2,7 @@
 from expression import Variable, Linear, Relu, Max, Multiplication, Constant, Sum, Neg, One_hot, Greater_Zero, \
     Geq, BinMult, Gt_Int, Impl, IndicatorToggle, TopKGroup, ExtremeGroup, Abs
 from keras_loader import KerasLoader
+from onnx_loader import OnnxLoader
 import gurobipy as grb
 import datetime
 import flags_constants as fc
@@ -363,8 +364,15 @@ def encodeNN(layers, input_lower_bounds, input_upper_bounds, net_prefix, mode='n
 
 
 def encode_NN_from_file(file_name, input_lower_bounds, input_upper_bounds, net_prefix, mode='normal'):
-    kl = KerasLoader()
+    suffix = file_name.split('.')[-1]
+    if suffix == 'h5':
+        kl = KerasLoader()
+    elif suffix == 'onnx':
+        kl = OnnxLoader()
+    else:
+        raise ValueError('File type .{} is not supported!'.format(suffix))
     kl.load(file_name)
+    
 
     return encodeNN(kl.getHiddenLayers(), input_lower_bounds, input_upper_bounds, net_prefix, mode)
 
@@ -825,7 +833,13 @@ def encode_equivalence(layers1, layers2, input_lower_bounds, input_upper_bounds,
 
 
 def encode_from_file(path, input_lower_bounds, input_upper_bounds, mode='normal'):
-    kl = KerasLoader()
+    suffix = path.split('.')[-1]
+    if suffix == 'h5':
+        kl = KerasLoader()
+    elif suffix == 'onnx':
+        kl = OnnxLoader()
+    else:
+        raise ValueError('File type .{} is not supported!'.format(suffix))
     kl.load(path)
 
     layers = kl.getHiddenLayers()
@@ -835,11 +849,23 @@ def encode_from_file(path, input_lower_bounds, input_upper_bounds, mode='normal'
 
 def encode_equivalence_from_file(path1, path2, input_lower_bounds, input_upper_bounds, compared='outputs',
                        comparator='diff_zero'):
-    kl1 = KerasLoader()
+    suffix = path1.split('.')[-1]
+    if suffix == 'h5':
+        kl1 = KerasLoader()
+    elif suffix == 'onnx':
+        kl1 = OnnxLoader()
+    else:
+        raise ValueError('File type .{} is not supported!'.format(suffix))
     kl1.load(path1)
     layers1 = kl1.getHiddenLayers()
 
-    kl2 = KerasLoader()
+    suffix = path2.split('.')[-1]
+    if suffix == 'h5':
+        kl2 = KerasLoader()
+    elif suffix == 'onnx':
+        kl2 = OnnxLoader()
+    else:
+        raise ValueError('File type .{} is not supported!'.format(suffix))
     kl2.load(path2)
     layers2 = kl2.getHiddenLayers()
 

--- a/onnx_loader.py
+++ b/onnx_loader.py
@@ -52,14 +52,12 @@ class OnnxLoader(NNLoader):
             elif op == 'MatMul':
                 if node.input[1] in init_map:
                     init = init_map[node.input[1]]
+                    weight = numpy_helper.to_array(init)
                 else:
                     init = init_map[node.input[0]]
-                weight = numpy_helper.to_array(init)
+                    weight = numpy_helper.to_array(init).T
             elif op == 'Relu':
-                if weight.shape[1]==bias.shape[0]:
-                    weights = np.vstack((weight, bias))
-                else:
-                    weights = np.vstack((weight.T, bias))
+                weights = np.vstack((weight, bias))
                 numNeurons = len(bias)
                 print(numNeurons)
                 self.layers.append(('relu', numNeurons, weights))
@@ -67,10 +65,7 @@ class OnnxLoader(NNLoader):
                 raise ValueError('Operation {} is not supported!'.format(op))
 
         if weight is not None and bias is not None:
-            if weight.shape[1]==bias.shape[0]:
-                weights = np.vstack((weight, bias))
-            else:
-                weights = np.vstack((weight.T, bias))
+            weights = np.vstack((weight, bias))
             numNeurons = len(bias)
             self.layers.append(('linear', numNeurons, weights))
 

--- a/onnx_loader.py
+++ b/onnx_loader.py
@@ -61,6 +61,7 @@ class OnnxLoader(NNLoader):
                 else:
                     weights = np.vstack((weight.T, bias))
                 numNeurons = len(bias)
+                print(numNeurons)
                 self.layers.append(('relu', numNeurons, weights))
             else:
                 raise ValueError('Operation {} is not supported!'.format(op))


### PR DESCRIPTION
I still had issues parsing certain ONNX networks (in particular the ones produced by the nnet2onnx generator).
In those networks the order `node.input` was reversed and additionally there were issues with the `vstack` dimensions.
I added suitable case distinctions which should mitigate this issue.

While I'm not entirely certain that this is a parsing issue and not a generator issue of nnet, it will be useful for our experiments -- feel free to merge if you like.